### PR TITLE
chore(deps): update and clean up dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,13 +133,16 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=dd7a999#dd7a999d9efe259c47a34dde046952de795a8f6a"
+source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
+ "arbitrary",
  "c-kzg",
+ "proptest",
+ "proptest-derive",
  "serde",
 ]
 
@@ -164,7 +167,7 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=dd7a999#dd7a999d9efe259c47a34dde046952de795a8f6a"
+source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -182,7 +185,7 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=dd7a999#dd7a999d9efe259c47a34dde046952de795a8f6a"
+source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
 dependencies = [
  "alloy-primitives",
  "alloy-serde",
@@ -254,7 +257,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=dd7a999#dd7a999d9efe259c47a34dde046952de795a8f6a"
+source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -273,7 +276,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-anvil"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=dd7a999#dd7a999d9efe259c47a34dde046952de795a8f6a"
+source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
 dependencies = [
  "alloy-primitives",
  "alloy-serde",
@@ -283,19 +286,20 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-beacon"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=dd7a999#dd7a999d9efe259c47a34dde046952de795a8f6a"
+source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "serde",
  "serde_with",
+ "thiserror",
 ]
 
 [[package]]
 name = "alloy-rpc-types-engine"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=dd7a999#dd7a999d9efe259c47a34dde046952de795a8f6a"
+source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -313,7 +317,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-trace"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=dd7a999#dd7a999d9efe259c47a34dde046952de795a8f6a"
+source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -325,7 +329,7 @@ dependencies = [
 [[package]]
 name = "alloy-serde"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=dd7a999#dd7a999d9efe259c47a34dde046952de795a8f6a"
+source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -5177,7 +5181,7 @@ dependencies = [
 [[package]]
 name = "reth"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "ahash",
  "alloy-rlp",
@@ -5208,11 +5212,14 @@ dependencies = [
  "reth-consensus",
  "reth-consensus-common",
  "reth-db",
+ "reth-db-common",
  "reth-discv4",
+ "reth-discv5",
  "reth-downloaders",
  "reth-ethereum-payload-builder",
  "reth-evm",
  "reth-exex",
+ "reth-fs-util",
  "reth-interfaces",
  "reth-network",
  "reth-network-api",
@@ -5222,6 +5229,7 @@ dependencies = [
  "reth-node-core",
  "reth-node-ethereum",
  "reth-node-events",
+ "reth-optimism-primitives",
  "reth-payload-builder",
  "reth-payload-validator",
  "reth-primitives",
@@ -5251,20 +5259,22 @@ dependencies = [
 [[package]]
 name = "reth-auto-seal-consensus"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "futures-util",
  "reth-beacon-consensus",
  "reth-consensus",
  "reth-engine-primitives",
  "reth-evm",
- "reth-interfaces",
+ "reth-execution-errors",
+ "reth-network-p2p",
  "reth-network-types",
  "reth-primitives",
  "reth-provider",
  "reth-revm",
  "reth-rpc-types",
  "reth-stages-api",
+ "reth-tokio-util",
  "reth-transaction-pool",
  "tokio",
  "tokio-stream",
@@ -5274,14 +5284,13 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "alloy-rlp",
  "futures-core",
  "futures-util",
  "metrics",
  "reth-engine-primitives",
- "reth-interfaces",
  "reth-metrics",
  "reth-payload-builder",
  "reth-primitives",
@@ -5289,7 +5298,7 @@ dependencies = [
  "reth-revm",
  "reth-tasks",
  "reth-transaction-pool",
- "revm",
+ "revm 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
  "tracing",
 ]
@@ -5297,7 +5306,7 @@ dependencies = [
 [[package]]
 name = "reth-beacon-consensus"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "futures",
  "metrics",
@@ -5326,22 +5335,24 @@ dependencies = [
 [[package]]
 name = "reth-blockchain-tree"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "aquamarine",
  "linked_hash_set",
- "lru",
  "metrics",
  "parking_lot 0.12.2",
+ "reth-blockchain-tree-api",
  "reth-consensus",
  "reth-db",
  "reth-evm",
- "reth-interfaces",
+ "reth-execution-errors",
  "reth-metrics",
+ "reth-network",
  "reth-primitives",
  "reth-provider",
  "reth-revm",
  "reth-stages-api",
+ "reth-storage-errors",
  "reth-trie",
  "reth-trie-parallel",
  "tokio",
@@ -5349,9 +5360,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-blockchain-tree-api"
+version = "0.2.0-beta.7"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
+dependencies = [
+ "reth-consensus",
+ "reth-execution-errors",
+ "reth-primitives",
+ "reth-storage-errors",
+ "thiserror",
+]
+
+[[package]]
 name = "reth-cli-runner"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -5361,8 +5384,9 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
+ "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
@@ -5375,7 +5399,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -5386,22 +5410,19 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "confy",
  "humantime-serde",
- "reth-discv4",
- "reth-net-nat",
  "reth-network",
  "reth-primitives",
- "secp256k1 0.28.2",
  "serde",
 ]
 
 [[package]]
 name = "reth-consensus"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "auto_impl",
  "reth-primitives",
@@ -5411,16 +5432,17 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "reth-consensus",
+ "reth-optimism-primitives",
  "reth-primitives",
 ]
 
 [[package]]
 name = "reth-db"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -5435,11 +5457,12 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "reth-codecs",
- "reth-interfaces",
+ "reth-fs-util",
  "reth-libmdbx",
  "reth-metrics",
  "reth-nippy-jar",
  "reth-primitives",
+ "reth-storage-errors",
  "reth-tracing",
  "rustc-hash",
  "serde",
@@ -5449,9 +5472,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-db-common"
+version = "0.2.0-beta.7"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
+dependencies = [
+ "eyre",
+ "reth-codecs",
+ "reth-config",
+ "reth-db",
+ "reth-etl",
+ "reth-interfaces",
+ "reth-primitives",
+ "reth-provider",
+ "reth-trie",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "reth-discv4"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "alloy-rlp",
  "discv5",
@@ -5462,6 +5505,7 @@ dependencies = [
  "reth-net-nat",
  "reth-network-types",
  "reth-primitives",
+ "schnellru",
  "secp256k1 0.28.2",
  "serde",
  "thiserror",
@@ -5473,7 +5517,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "alloy-rlp",
  "derive_more",
@@ -5497,7 +5541,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "data-encoding",
  "enr",
@@ -5520,7 +5564,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "alloy-rlp",
  "futures",
@@ -5531,8 +5575,8 @@ dependencies = [
  "rayon",
  "reth-config",
  "reth-consensus",
- "reth-interfaces",
  "reth-metrics",
+ "reth-network-p2p",
  "reth-network-types",
  "reth-primitives",
  "reth-provider",
@@ -5547,7 +5591,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "aes 0.8.4",
  "alloy-rlp",
@@ -5580,7 +5624,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "reth-primitives",
  "reth-rpc-types",
@@ -5589,9 +5633,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-errors"
+version = "0.2.0-beta.7"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
+dependencies = [
+ "reth-blockchain-tree-api",
+ "reth-consensus",
+ "reth-execution-errors",
+ "reth-fs-util",
+ "reth-storage-errors",
+ "thiserror",
+]
+
+[[package]]
 name = "reth-eth-wire"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -5618,12 +5675,12 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "derive_more",
- "reth-codecs",
+ "reth-codecs-derive",
  "reth-primitives",
  "serde",
  "thiserror",
@@ -5632,7 +5689,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "reth-consensus",
  "reth-consensus-common",
@@ -5642,14 +5699,14 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "alloy-rlp",
  "reth-engine-primitives",
  "reth-primitives",
  "reth-rpc-types",
  "reth-rpc-types-compat",
- "revm-primitives",
+ "revm-primitives 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "sha2 0.10.8",
 ]
@@ -5657,7 +5714,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -5673,22 +5730,24 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "reth-basic-payload-builder",
+ "reth-evm",
+ "reth-evm-ethereum",
  "reth-payload-builder",
  "reth-primitives",
  "reth-provider",
  "reth-revm",
  "reth-transaction-pool",
- "revm",
+ "revm 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
 ]
 
 [[package]]
 name = "reth-etl"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "rayon",
  "reth-db",
@@ -5698,32 +5757,56 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
+ "auto_impl",
  "futures-util",
- "reth-interfaces",
+ "reth-execution-errors",
  "reth-primitives",
- "revm",
- "revm-primitives",
+ "reth-storage-errors",
+ "revm 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-primitives 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "reth-evm-ethereum"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
+ "reth-ethereum-consensus",
  "reth-evm",
- "reth-interfaces",
  "reth-primitives",
  "reth-revm",
- "revm-primitives",
- "tracing",
+ "revm-primitives 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "reth-execution-errors"
+version = "0.2.0-beta.7"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
+dependencies = [
+ "reth-consensus",
+ "reth-primitives",
+ "reth-storage-errors",
+ "thiserror",
+]
+
+[[package]]
+name = "reth-execution-types"
+version = "0.2.0-beta.7"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
+dependencies = [
+ "reth-evm",
+ "reth-execution-errors",
+ "reth-primitives",
+ "reth-trie",
+ "revm 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "reth-exex"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "eyre",
  "metrics",
@@ -5742,27 +5825,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-fs-util"
+version = "0.2.0-beta.7"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
+dependencies = [
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "reth-interfaces"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
- "auto_impl",
- "clap",
- "futures",
- "reth-consensus",
- "reth-eth-wire-types",
- "reth-network-api",
- "reth-network-types",
- "reth-primitives",
- "thiserror",
- "tokio",
- "tracing",
+ "reth-blockchain-tree-api",
+ "reth-errors",
+ "reth-execution-errors",
+ "reth-network-p2p",
+ "reth-storage-errors",
 ]
 
 [[package]]
 name = "reth-ipc"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5783,7 +5869,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "bitflags 2.5.0",
  "byteorder",
@@ -5801,7 +5887,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "bindgen",
  "cc",
@@ -5811,7 +5897,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "futures",
  "metrics",
@@ -5823,7 +5909,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics-derive"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "once_cell",
  "proc-macro2",
@@ -5835,17 +5921,17 @@ dependencies = [
 [[package]]
 name = "reth-net-common"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
+ "alloy-primitives",
  "pin-project",
- "reth-network-types",
  "tokio",
 ]
 
 [[package]]
 name = "reth-net-nat"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "igd-next",
  "pin-project-lite",
@@ -5859,7 +5945,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
@@ -5883,10 +5969,10 @@ dependencies = [
  "reth-dns-discovery",
  "reth-ecies",
  "reth-eth-wire",
- "reth-interfaces",
  "reth-metrics",
  "reth-net-common",
  "reth-network-api",
+ "reth-network-p2p",
  "reth-network-types",
  "reth-primitives",
  "reth-provider",
@@ -5909,13 +5995,12 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
+ "alloy-primitives",
  "enr",
- "reth-discv4",
  "reth-eth-wire",
  "reth-network-types",
- "reth-primitives",
  "reth-rpc-types",
  "serde",
  "thiserror",
@@ -5923,9 +6008,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-network-p2p"
+version = "0.2.0-beta.7"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
+dependencies = [
+ "auto_impl",
+ "futures",
+ "reth-consensus",
+ "reth-eth-wire-types",
+ "reth-network-api",
+ "reth-network-types",
+ "reth-primitives",
+ "reth-storage-errors",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "reth-network-types"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -5939,7 +6042,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5948,7 +6051,7 @@ dependencies = [
  "lz4_flex",
  "memmap2",
  "ph",
- "reth-primitives",
+ "reth-fs-util",
  "serde",
  "sucds",
  "thiserror",
@@ -5959,7 +6062,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "reth-db",
  "reth-engine-primitives",
@@ -5974,7 +6077,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "aquamarine",
  "confy",
@@ -5988,11 +6091,12 @@ dependencies = [
  "reth-config",
  "reth-consensus",
  "reth-db",
+ "reth-db-common",
  "reth-downloaders",
  "reth-evm",
  "reth-exex",
- "reth-interfaces",
  "reth-network",
+ "reth-network-p2p",
  "reth-node-api",
  "reth-node-core",
  "reth-node-events",
@@ -6003,6 +6107,7 @@ dependencies = [
  "reth-rpc",
  "reth-rpc-engine-api",
  "reth-rpc-layer",
+ "reth-rpc-types",
  "reth-stages",
  "reth-static-file",
  "reth-tasks",
@@ -6015,8 +6120,9 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
+ "alloy-rpc-types-engine",
  "clap",
  "const-str",
  "derive_more",
@@ -6035,33 +6141,28 @@ dependencies = [
  "procfs",
  "rand 0.8.5",
  "reth-beacon-consensus",
- "reth-codecs",
  "reth-config",
  "reth-consensus-common",
  "reth-db",
  "reth-discv4",
  "reth-discv5",
  "reth-engine-primitives",
- "reth-etl",
- "reth-evm",
- "reth-interfaces",
+ "reth-fs-util",
  "reth-metrics",
  "reth-net-nat",
  "reth-network",
- "reth-network-api",
+ "reth-network-p2p",
  "reth-primitives",
  "reth-provider",
  "reth-rpc",
  "reth-rpc-api",
  "reth-rpc-builder",
- "reth-rpc-engine-api",
- "reth-rpc-layer",
  "reth-rpc-types",
  "reth-rpc-types-compat",
+ "reth-storage-errors",
  "reth-tasks",
  "reth-tracing",
  "reth-transaction-pool",
- "reth-trie",
  "secp256k1 0.28.2",
  "serde",
  "serde_json",
@@ -6077,7 +6178,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "eyre",
  "reth-basic-payload-builder",
@@ -6095,7 +6196,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "futures",
  "humantime",
@@ -6115,9 +6216,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-optimism-primitives"
+version = "0.2.0-beta.7"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
+
+[[package]]
 name = "reth-payload-builder"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "futures-util",
  "metrics",
@@ -6138,7 +6244,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "reth-primitives",
  "reth-rpc-types",
@@ -6148,9 +6254,10 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "alloy-chains",
+ "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
@@ -6160,7 +6267,6 @@ dependencies = [
  "byteorder",
  "bytes",
  "c-kzg",
- "clap",
  "derive_more",
  "itertools 0.12.1",
  "modular-bitfield",
@@ -6172,13 +6278,13 @@ dependencies = [
  "reth-codecs",
  "reth-ethereum-forks",
  "reth-network-types",
- "revm",
- "revm-primitives",
+ "reth-static-file-types",
+ "revm 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-primitives 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "roaring",
  "secp256k1 0.28.2",
  "serde",
  "serde_json",
- "strum",
  "tempfile",
  "thiserror",
  "zstd",
@@ -6187,7 +6293,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -6198,15 +6304,20 @@ dependencies = [
  "parking_lot 0.12.2",
  "pin-project",
  "rayon",
+ "reth-blockchain-tree-api",
  "reth-codecs",
  "reth-db",
  "reth-evm",
+ "reth-execution-types",
+ "reth-fs-util",
  "reth-interfaces",
  "reth-metrics",
  "reth-nippy-jar",
  "reth-primitives",
+ "reth-storage-api",
+ "reth-storage-errors",
  "reth-trie",
- "revm",
+ "revm 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum",
  "tokio",
  "tokio-stream",
@@ -6216,7 +6327,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "itertools 0.12.1",
  "metrics",
@@ -6230,28 +6341,28 @@ dependencies = [
  "reth-tokio-util",
  "thiserror",
  "tokio",
- "tokio-stream",
  "tracing",
 ]
 
 [[package]]
 name = "reth-revm"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "alloy-eips",
  "reth-consensus-common",
- "reth-interfaces",
+ "reth-execution-errors",
  "reth-primitives",
- "reth-provider",
- "revm",
+ "reth-storage-api",
+ "reth-storage-errors",
+ "revm 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
 ]
 
 [[package]]
 name = "reth-rpc"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -6271,8 +6382,8 @@ dependencies = [
  "pin-project",
  "rand 0.8.5",
  "reth-consensus-common",
+ "reth-errors",
  "reth-evm",
- "reth-interfaces",
  "reth-metrics",
  "reth-network-api",
  "reth-network-types",
@@ -6285,9 +6396,9 @@ dependencies = [
  "reth-rpc-types-compat",
  "reth-tasks",
  "reth-transaction-pool",
- "revm",
+ "revm 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "revm-inspectors",
- "revm-primitives",
+ "revm-primitives 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "schnellru",
  "secp256k1 0.28.2",
  "serde",
@@ -6303,7 +6414,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "jsonrpsee",
  "reth-engine-primitives",
@@ -6317,7 +6428,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "hyper",
  "jsonrpsee",
@@ -6345,7 +6456,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "async-trait",
  "jsonrpsee-core",
@@ -6370,17 +6481,13 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
+ "alloy-rpc-types-engine",
  "http",
  "http-body",
  "hyper",
- "jsonwebtoken 8.3.0",
  "pin-project",
- "rand 0.8.5",
- "reth-primitives",
- "serde",
- "thiserror",
  "tower",
  "tracing",
 ]
@@ -6388,7 +6495,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-types"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -6399,14 +6506,12 @@ dependencies = [
  "jsonrpsee-types",
  "serde",
  "serde_json",
- "serde_with",
- "thiserror",
 ]
 
 [[package]]
 name = "reth-rpc-types-compat"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "alloy-rlp",
  "alloy-rpc-types",
@@ -6417,7 +6522,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "futures-util",
  "itertools 0.12.1",
@@ -6444,7 +6549,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "aquamarine",
  "auto_impl",
@@ -6461,31 +6566,68 @@ dependencies = [
  "reth-tokio-util",
  "thiserror",
  "tokio",
- "tokio-stream",
  "tracing",
 ]
 
 [[package]]
 name = "reth-static-file"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "parking_lot 0.12.2",
  "rayon",
  "reth-db",
- "reth-interfaces",
  "reth-nippy-jar",
  "reth-primitives",
  "reth-provider",
+ "reth-storage-errors",
  "reth-tokio-util",
+ "tokio",
  "tokio-stream",
  "tracing",
 ]
 
 [[package]]
+name = "reth-static-file-types"
+version = "0.2.0-beta.7"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
+dependencies = [
+ "alloy-primitives",
+ "clap",
+ "derive_more",
+ "serde",
+ "strum",
+]
+
+[[package]]
+name = "reth-storage-api"
+version = "0.2.0-beta.7"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
+dependencies = [
+ "auto_impl",
+ "reth-db",
+ "reth-execution-types",
+ "reth-primitives",
+ "reth-storage-errors",
+ "reth-trie",
+ "revm 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "reth-storage-errors"
+version = "0.2.0-beta.7"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
+dependencies = [
+ "clap",
+ "reth-fs-util",
+ "reth-primitives",
+ "thiserror",
+]
+
+[[package]]
 name = "reth-tasks"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "dyn-clone",
  "futures-util",
@@ -6502,16 +6644,17 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "tokio",
  "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
 name = "reth-tracing"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "clap",
  "eyre",
@@ -6526,7 +6669,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
@@ -6538,13 +6681,12 @@ dependencies = [
  "parking_lot 0.12.2",
  "paste",
  "rand 0.8.5",
- "reth-eth-wire",
+ "reth-eth-wire-types",
+ "reth-fs-util",
  "reth-metrics",
- "reth-network-types",
  "reth-primitives",
  "reth-provider",
  "reth-tasks",
- "revm",
  "rustc-hash",
  "schnellru",
  "serde",
@@ -6558,17 +6700,17 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "alloy-rlp",
  "auto_impl",
  "derive_more",
  "metrics",
  "reth-db",
- "reth-interfaces",
+ "reth-execution-errors",
  "reth-metrics",
  "reth-primitives",
- "revm",
+ "revm 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "tracing",
 ]
@@ -6576,7 +6718,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=aefcfff25fd3ec534b34337c9838c44ccdbab9b5#aefcfff25fd3ec534b34337c9838c44ccdbab9b5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d777d5f#d777d5f2705d416e1e42c883c744483df1de81c1"
 dependencies = [
  "alloy-rlp",
  "derive_more",
@@ -6584,7 +6726,7 @@ dependencies = [
  "metrics",
  "rayon",
  "reth-db",
- "reth-interfaces",
+ "reth-execution-errors",
  "reth-metrics",
  "reth-primitives",
  "reth-provider",
@@ -6604,8 +6746,22 @@ dependencies = [
  "auto_impl",
  "cfg-if",
  "dyn-clone",
- "revm-interpreter",
- "revm-precompile",
+ "revm-interpreter 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-precompile 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "revm"
+version = "9.0.0"
+source = "git+https://github.com/bluealloy/revm?rev=a28a543#a28a5439b9cfb7494cbd670da10cbedcfe6c5854"
+dependencies = [
+ "auto_impl",
+ "cfg-if",
+ "dyn-clone",
+ "revm-interpreter 5.0.0 (git+https://github.com/bluealloy/revm?rev=a28a543)",
+ "revm-precompile 7.0.0 (git+https://github.com/bluealloy/revm?rev=a28a543)",
  "serde",
  "serde_json",
 ]
@@ -6613,7 +6769,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/evm-inspectors?rev=21a2db5#21a2db5a3a828a35e82b116e5d046a9efaca1449"
+source = "git+https://github.com/paradigmxyz/evm-inspectors?rev=ed5450e#ed5450e7169ce0237e791fed661688c55997a0ac"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -6623,7 +6779,7 @@ dependencies = [
  "boa_engine",
  "boa_gc",
  "colorchoice",
- "revm",
+ "revm 9.0.0 (git+https://github.com/bluealloy/revm?rev=a28a543)",
  "serde_json",
  "thiserror",
 ]
@@ -6634,7 +6790,16 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a58182c7454179826f9dad2ca577661963092ce9d0fd0c9d682c1e9215a72e70"
 dependencies = [
- "revm-primitives",
+ "revm-primitives 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "5.0.0"
+source = "git+https://github.com/bluealloy/revm?rev=a28a543#a28a5439b9cfb7494cbd670da10cbedcfe6c5854"
+dependencies = [
+ "revm-primitives 4.0.0 (git+https://github.com/bluealloy/revm?rev=a28a543)",
  "serde",
 ]
 
@@ -6645,10 +6810,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc8af9aa737eef0509a50d9f3cc1a631557a00ef2e70a3aa8a75d9ee0ed275bb"
 dependencies = [
  "aurora-engine-modexp",
+ "blst",
  "c-kzg",
  "k256",
  "once_cell",
- "revm-primitives",
+ "revm-primitives 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ripemd",
+ "secp256k1 0.29.0",
+ "sha2 0.10.8",
+ "substrate-bn",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "7.0.0"
+source = "git+https://github.com/bluealloy/revm?rev=a28a543#a28a5439b9cfb7494cbd670da10cbedcfe6c5854"
+dependencies = [
+ "aurora-engine-modexp",
+ "c-kzg",
+ "k256",
+ "once_cell",
+ "revm-primitives 4.0.0 (git+https://github.com/bluealloy/revm?rev=a28a543)",
  "ripemd",
  "secp256k1 0.29.0",
  "sha2 0.10.8",
@@ -6673,6 +6855,23 @@ dependencies = [
  "hashbrown 0.14.5",
  "hex",
  "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "4.0.0"
+source = "git+https://github.com/bluealloy/revm?rev=a28a543#a28a5439b9cfb7494cbd670da10cbedcfe6c5854"
+dependencies = [
+ "alloy-primitives",
+ "auto_impl",
+ "bitflags 2.5.0",
+ "bitvec",
+ "cfg-if",
+ "dyn-clone",
+ "enumn",
+ "hashbrown 0.14.5",
+ "hex",
  "serde",
 ]
 
@@ -7154,9 +7353,9 @@ checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
-version = "1.0.201"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
@@ -7172,9 +7371,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.201"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7332,8 +7531,8 @@ dependencies = [
  "reth-node-api",
  "reth-primitives",
  "reth-provider",
+ "reth-revm",
  "reth-tracing",
- "revm",
  "serde_json",
  "shadow-reth-common",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5298,7 +5298,7 @@ dependencies = [
  "reth-revm",
  "reth-tasks",
  "reth-transaction-pool",
- "revm 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm",
  "tokio",
  "tracing",
 ]
@@ -5706,7 +5706,7 @@ dependencies = [
  "reth-primitives",
  "reth-rpc-types",
  "reth-rpc-types-compat",
- "revm-primitives 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-primitives",
  "serde",
  "sha2 0.10.8",
 ]
@@ -5740,7 +5740,7 @@ dependencies = [
  "reth-provider",
  "reth-revm",
  "reth-transaction-pool",
- "revm 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm",
  "tracing",
 ]
 
@@ -5764,8 +5764,8 @@ dependencies = [
  "reth-execution-errors",
  "reth-primitives",
  "reth-storage-errors",
- "revm 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "revm-primitives 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm",
+ "revm-primitives",
 ]
 
 [[package]]
@@ -5777,7 +5777,7 @@ dependencies = [
  "reth-evm",
  "reth-primitives",
  "reth-revm",
- "revm-primitives 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-primitives",
 ]
 
 [[package]]
@@ -5800,7 +5800,7 @@ dependencies = [
  "reth-execution-errors",
  "reth-primitives",
  "reth-trie",
- "revm 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm",
 ]
 
 [[package]]
@@ -6279,8 +6279,8 @@ dependencies = [
  "reth-ethereum-forks",
  "reth-network-types",
  "reth-static-file-types",
- "revm 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "revm-primitives 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm",
+ "revm-primitives",
  "roaring",
  "secp256k1 0.28.2",
  "serde",
@@ -6317,7 +6317,7 @@ dependencies = [
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
- "revm 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm",
  "strum",
  "tokio",
  "tokio-stream",
@@ -6355,7 +6355,7 @@ dependencies = [
  "reth-primitives",
  "reth-storage-api",
  "reth-storage-errors",
- "revm 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm",
  "tracing",
 ]
 
@@ -6396,9 +6396,9 @@ dependencies = [
  "reth-rpc-types-compat",
  "reth-tasks",
  "reth-transaction-pool",
- "revm 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm",
  "revm-inspectors",
- "revm-primitives 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-primitives",
  "schnellru",
  "secp256k1 0.28.2",
  "serde",
@@ -6610,7 +6610,7 @@ dependencies = [
  "reth-primitives",
  "reth-storage-errors",
  "reth-trie",
- "revm 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm",
 ]
 
 [[package]]
@@ -6710,7 +6710,7 @@ dependencies = [
  "reth-execution-errors",
  "reth-metrics",
  "reth-primitives",
- "revm 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm",
  "thiserror",
  "tracing",
 ]
@@ -6740,28 +6740,13 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a2c336f9921588e50871c00024feb51a521eca50ce6d01494bb9c50f837c8ed"
-dependencies = [
- "auto_impl",
- "cfg-if",
- "dyn-clone",
- "revm-interpreter 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "revm-precompile 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "revm"
-version = "9.0.0"
 source = "git+https://github.com/bluealloy/revm?rev=a28a543#a28a5439b9cfb7494cbd670da10cbedcfe6c5854"
 dependencies = [
  "auto_impl",
  "cfg-if",
  "dyn-clone",
- "revm-interpreter 5.0.0 (git+https://github.com/bluealloy/revm?rev=a28a543)",
- "revm-precompile 7.0.0 (git+https://github.com/bluealloy/revm?rev=a28a543)",
+ "revm-interpreter",
+ "revm-precompile",
  "serde",
  "serde_json",
 ]
@@ -6779,7 +6764,7 @@ dependencies = [
  "boa_engine",
  "boa_gc",
  "colorchoice",
- "revm 9.0.0 (git+https://github.com/bluealloy/revm?rev=a28a543)",
+ "revm",
  "serde_json",
  "thiserror",
 ]
@@ -6787,50 +6772,23 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a58182c7454179826f9dad2ca577661963092ce9d0fd0c9d682c1e9215a72e70"
-dependencies = [
- "revm-primitives 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde",
-]
-
-[[package]]
-name = "revm-interpreter"
-version = "5.0.0"
 source = "git+https://github.com/bluealloy/revm?rev=a28a543#a28a5439b9cfb7494cbd670da10cbedcfe6c5854"
 dependencies = [
- "revm-primitives 4.0.0 (git+https://github.com/bluealloy/revm?rev=a28a543)",
+ "revm-primitives",
  "serde",
 ]
 
 [[package]]
 name = "revm-precompile"
 version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc8af9aa737eef0509a50d9f3cc1a631557a00ef2e70a3aa8a75d9ee0ed275bb"
+source = "git+https://github.com/bluealloy/revm?rev=a28a543#a28a5439b9cfb7494cbd670da10cbedcfe6c5854"
 dependencies = [
  "aurora-engine-modexp",
  "blst",
  "c-kzg",
  "k256",
  "once_cell",
- "revm-primitives 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ripemd",
- "secp256k1 0.29.0",
- "sha2 0.10.8",
- "substrate-bn",
-]
-
-[[package]]
-name = "revm-precompile"
-version = "7.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=a28a543#a28a5439b9cfb7494cbd670da10cbedcfe6c5854"
-dependencies = [
- "aurora-engine-modexp",
- "c-kzg",
- "k256",
- "once_cell",
- "revm-primitives 4.0.0 (git+https://github.com/bluealloy/revm?rev=a28a543)",
+ "revm-primitives",
  "ripemd",
  "secp256k1 0.29.0",
  "sha2 0.10.8",
@@ -6840,8 +6798,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9bf5d465e64b697da6a111cb19e798b5b2ebb18e5faf2ad48e9e8d47c64add2"
+source = "git+https://github.com/bluealloy/revm?rev=a28a543#a28a5439b9cfb7494cbd670da10cbedcfe6c5854"
 dependencies = [
  "alloy-primitives",
  "auto_impl",
@@ -6855,23 +6812,6 @@ dependencies = [
  "hashbrown 0.14.5",
  "hex",
  "once_cell",
- "serde",
-]
-
-[[package]]
-name = "revm-primitives"
-version = "4.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=a28a543#a28a5439b9cfb7494cbd670da10cbedcfe6c5854"
-dependencies = [
- "alloy-primitives",
- "auto_impl",
- "bitflags 2.5.0",
- "bitvec",
- "cfg-if",
- "dyn-clone",
- "enumn",
- "hashbrown 0.14.5",
- "hex",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,3 +130,9 @@ serde_json = "1.0.117"
 # RPC
 jsonrpsee = "0.22.5"
 sqlx = { version = "0.7.4", features = ["sqlite", "runtime-tokio"] }
+
+[patch.crates-io]
+revm = { git = "https://github.com/bluealloy/revm", rev = "a28a543" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "a28a543" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "a28a543" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "a28a543" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,40 +107,26 @@ shadow-reth-rpc = { path = "crates/rpc" }
 shadow-reth-common = { path = "crates/common" }
 
 # Reth
-reth = { git = "https://github.com/paradigmxyz/reth.git", rev = "aefcfff25fd3ec534b34337c9838c44ccdbab9b5" }
-reth-exex = { git = "https://github.com/paradigmxyz/reth.git", rev = "aefcfff25fd3ec534b34337c9838c44ccdbab9b5" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "aefcfff25fd3ec534b34337c9838c44ccdbab9b5" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth.git", rev = "aefcfff25fd3ec534b34337c9838c44ccdbab9b5" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth.git", rev = "aefcfff25fd3ec534b34337c9838c44ccdbab9b5" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth.git", rev = "aefcfff25fd3ec534b34337c9838c44ccdbab9b5" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "aefcfff25fd3ec534b34337c9838c44ccdbab9b5" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth.git", rev = "aefcfff25fd3ec534b34337c9838c44ccdbab9b5" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth.git", rev = "aefcfff25fd3ec534b34337c9838c44ccdbab9b5" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth.git", rev = "aefcfff25fd3ec534b34337c9838c44ccdbab9b5" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth.git", rev = "aefcfff25fd3ec534b34337c9838c44ccdbab9b5" }
-reth-interfaces = { git = "https://github.com/paradigmxyz/reth.git", rev = "aefcfff25fd3ec534b34337c9838c44ccdbab9b5" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth.git", rev = "aefcfff25fd3ec534b34337c9838c44ccdbab9b5" }
-
-# Alloy
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "dd7a999" }
-alloy-sol-types = "0.7.2"
-alloy-rlp = "0.3.4"
-
-# Revm
-revm = { version = "9.0.0", features = ["std", "secp256k1"], default-features = false }
-revm-primitives = { version = "4.0.0", features = ["std"], default-features = false }
-revm-inspectors = { git = "https://github.com/paradigmxyz/evm-inspectors", rev = "21a2db5" }
+reth = { git = "https://github.com/paradigmxyz/reth.git", rev = "d777d5f" }
+reth-exex = { git = "https://github.com/paradigmxyz/reth.git", rev = "d777d5f" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "d777d5f" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth.git", rev = "d777d5f" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth.git", rev = "d777d5f" }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "d777d5f" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth.git", rev = "d777d5f" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth.git", rev = "d777d5f" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth.git", rev = "d777d5f" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth.git", rev = "d777d5f" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth.git", rev = "d777d5f" }
 
 # Crates.io
 eyre = "0.6.12"
-tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.37.0", features = ["macros", "rt-multi-thread"] }
 futures = "0.3.30"
 tracing = "0.1.40"
-serde = "1.0.201"
+serde = "1.0.203"
 serde_json = "1.0.117"
 
 # RPC
-jsonrpsee = "0.22"
-jsonrpsee-core = "0.22"
-jsonrpsee-types = "0.22"
+jsonrpsee = "0.22.5"
 sqlx = { version = "0.7.4", features = ["sqlite", "runtime-tokio"] }

--- a/crates/common/src/db.rs
+++ b/crates/common/src/db.rs
@@ -1,8 +1,8 @@
+use std::str::FromStr;
+
 use eyre::Result;
 use reth_primitives::B256;
 use reth_tracing::tracing::debug;
-use std::str::FromStr;
-
 use sqlx::{
     sqlite::{SqliteConnectOptions, SqlitePoolOptions},
     Pool, Sqlite,

--- a/crates/common/src/hex.rs
+++ b/crates/common/src/hex.rs
@@ -6,6 +6,7 @@ pub trait ToLowerHex {
     ///
     /// ```
     /// use reth_primitives::Address;
+    /// use shadow_reth_common::ToLowerHex;
     ///
     /// let value = Address::ZERO;
     /// assert_eq!(value.to_lower_hex(), "0x0000000000000000000000000000000000000000");

--- a/crates/exex/Cargo.toml
+++ b/crates/exex/Cargo.toml
@@ -23,9 +23,7 @@ reth-node-api.workspace = true
 reth-primitives.workspace = true
 reth-provider.workspace = true
 reth-tracing.workspace = true
-
-# Revm
-revm.workspace = true
+reth-revm.workspace = true
 
 # Crates
 eyre.workspace = true

--- a/crates/exex/src/db.rs
+++ b/crates/exex/src/db.rs
@@ -1,11 +1,12 @@
+use std::ops::{Deref, DerefMut};
+
 use reth_primitives::{Address, B256, KECCAK_EMPTY, U256};
 use reth_provider::{ProviderError, StateProvider};
-use revm::{
+use reth_revm::{
     db::DatabaseRef,
     primitives::{AccountInfo, Bytecode},
     Database,
 };
-use std::ops::{Deref, DerefMut};
 
 use crate::contracts::ShadowContracts;
 

--- a/crates/exex/src/execution.rs
+++ b/crates/exex/src/execution.rs
@@ -7,14 +7,14 @@ use reth_primitives::{
     revm::env::fill_tx_env, Block, BlockWithSenders, ChainSpec, Header, TransactionSigned,
 };
 use reth_provider::StateProvider;
-use reth_tracing::tracing::{debug, error};
-use revm::{
+use reth_revm::{
     db::{states::bundle_state::BundleRetention, State},
     primitives::{
         CfgEnvWithHandlerCfg, EVMError, ExecutionResult, HashMap, ResultAndState, B256, U256,
     },
     DatabaseCommit, Evm, StateBuilder,
 };
+use reth_tracing::tracing::{debug, error};
 use shadow_reth_common::{ShadowLog, ToLowerHex};
 
 use crate::db::ShadowDatabase;

--- a/crates/exex/src/execution.rs
+++ b/crates/exex/src/execution.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use eyre::Result;
 use reth_evm_ethereum::EthEvmConfig;
 use reth_node_api::{ConfigureEvm, ConfigureEvmEnv};
@@ -14,7 +16,6 @@ use revm::{
     DatabaseCommit, Evm, StateBuilder,
 };
 use shadow_reth_common::{ShadowLog, ToLowerHex};
-use std::sync::Arc;
 
 use crate::db::ShadowDatabase;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

When playing around with ExEx and the repo I noticed many unused dependencies declared in `Cargo.toml`

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Bumps dependencies
- Updates to the latest version of Reth
- Uses Reth's `revm` re-export in `reth-revm`
- Removes unused crates
- Small linting fixes, specifically consistent import order
- Small fix in doctest when running: `cargo test --workspace --all-targets`

Currently relies on revm patch (see: https://github.com/paradigmxyz/reth/pull/8447) but that should be able to be removed once new revm version has been released and updated in Reth (see: https://github.com/bluealloy/revm/pull/1463)